### PR TITLE
perf(awc): add mini-css-extract-plugin support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "hard-source-webpack-plugin": ">=0.6.4",
     "optimize-js-plugin": ">=0.0.4",
     "uglifyjs-webpack-plugin": ">=1.2.4",
-    "extract-text-webpack-plugin": ">=4.0.0"
+    "optimize-css-assets-webpack-plugin": ">=5.0.0",
+    "mini-css-extract-plugin": ">=0.4.2"
   }
 }

--- a/src/webpack.common.js
+++ b/src/webpack.common.js
@@ -10,7 +10,7 @@ const definePlugin = require('webpack/lib/DefinePlugin'),
   loaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin'),
   assetsPlugin = require('assets-webpack-plugin'),
   htmlWebpackPlugin = require('html-webpack-plugin'),
-  extractTextPlugin = require('extract-text-webpack-plugin'),
+  miniCssExtractPlugin = require('mini-css-extract-plugin'),
   scriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 
 const defaultConfig = function (options, root, settings) {
@@ -331,10 +331,13 @@ const browserConfig = function (options, root, settings) {
             root('node_modules')
           ],
           use: isProd
-            ? extractTextPlugin.extract({
-              fallback: 'style-loader',
-              use: `css-loader?minimize!postcss-loader!sass-loader!stylefmt-loader?config=${settings.paths.tools.config}/stylelint.config.js`
-            })
+            ? [
+              miniCssExtractPlugin.loader,
+              'css-loader?minimize',
+              'postcss-loader',
+              'sass-loader?minimize',
+              `stylefmt-loader?config=${settings.paths.tools.config}/stylelint.config.js`
+            ]
             // TODO: temporarily disabled for sourcemaps interference
             // : ['style-loader','css-loader?sourceMap','sass-loader?sourceMap'],
             : ['style-loader', 'css-loader', 'sass-loader']
@@ -452,7 +455,11 @@ const browserConfig = function (options, root, settings) {
        *
        * See: https://github.com/webpack/extract-text-webpack-plugin
        */
-      new extractTextPlugin(`[name]${isProd ? '.[chunkhash]' : ''}.style.css`),
+      // new extractTextPlugin(`[name]${isProd ? '.[chunkhash]' : ''}.style.css`),
+      new miniCssExtractPlugin({
+        filename: `[name]${isProd ? '.[contenthash]' : ''}.style.css`,
+        chunkFilename: `[id]${isProd ? '.[contenthash]' : ''}.style.css`
+      }),
 
       /**
        * Plugin: ScriptExtHtmlWebpackPlugin
@@ -484,5 +491,6 @@ const browserConfig = function (options, root, settings) {
  * See: http://webpack.github.io/docs/configuration.html#cli
  */
 module.exports = function (options, root, settings) {
-  return webpackMerge(defaultConfig(options, root, settings), options.platform === 'server' ? serverConfig(root, settings) : browserConfig(options, root, settings));
+  return webpackMerge(defaultConfig(options, root, settings), options.platform === 'server' ?
+    serverConfig(root, settings) : browserConfig(options, root, settings));
 };

--- a/src/webpack.common.prod.js
+++ b/src/webpack.common.prod.js
@@ -5,6 +5,7 @@ const commonConfig = require('./webpack.common'),
   webpackMerge = require('webpack-merge');
 
 const optimizeJsPlugin = require('optimize-js-plugin'),
+  optimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin'),
   loaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin'),
   uglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
@@ -105,10 +106,12 @@ const browserConfig = function(settings) {
       minimizer: !!settings.minimize
         ? [
           new uglifyJsPlugin({
+            parallel: true,
             uglifyOptions: {
               ecma: 6
             }
-          })
+          }),
+          new optimizeCSSAssetsPlugin({})
         ]
         : undefined
     },


### PR DESCRIPTION
Add mini-css-extract-plugin instead of extract-text-webpack-plugin
(this one is broken and affect to build time with webpack >= 4.18.0).
Add css optimization feature with optimize-css-assets-webpack-plugin.

** PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-seed/angular-webpack-config/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

** PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

** What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

** What is the new behavior?

** Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

** Other information
